### PR TITLE
Change categories route to use the name near the root.

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,5 +1,5 @@
 class CategoriesController < ApplicationController
   def show
-    @category = Category.find(params[:id])
+    @category = Category.find_by(title: params[:category_name])
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,6 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
   resources :trips, only: [:index]
-  resources :categories, only: [:show]
+  # resources :categories, only: [:show]
+  get '/:category_name', to: 'categories#show'
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,8 +1,8 @@
 Trip.destroy_all
 Category.destroy_all
 
-hot = Category.create(title: "Hot")
-cold = Category.create(title: "Cold")
+hot = Category.create(title: "hot")
+cold = Category.create(title: "cold")
 
 hot.trips.create(title: "Jungle", description: "Eat bugs!", image_url: "http://www.theimaginativeconservative.org/wp-content/uploads/2016/06/the-jungle.jpg", price: 500)
 cold.trips.create(title: "Antarctica", description: "Freeze your nuts off!", image_url: "http://getworldmedia.com/wp-content/uploads/2016/01/antarctica-factsAntarctica2.jpg", price: 1000)

--- a/spec/features/categories/a_visitor_can_see_all_trips_by_category_spec.rb
+++ b/spec/features/categories/a_visitor_can_see_all_trips_by_category_spec.rb
@@ -5,7 +5,7 @@ feature "visitor visits category show page" do
     trip1, trip2 = create_list(:trip_with_category, 2)
     category = trip1.categories.first
     trip3 = category.trips.create(title: "test", description: "test", price: 1.23, image_url: "url")
-    visit category_path(category)
+    visit "/#{category.title}"
 
     expect(page).to have_content trip1.title
     expect(page).to have_content trip3.title


### PR DESCRIPTION
@JStans12 or @bfpepper 
Modified the route for finding an individual category to align with the client spec. It now responses to "/:category_name"