### PR TITLE
js tests work... sort of

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ group :development, :test do
   gem 'launchy'
   gem 'database_cleaner'
   gem 'shoulda-matchers'
+  gem 'capybara-webkit'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,6 +54,9 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    capybara-webkit (1.1.0)
+      capybara (~> 2.0, >= 2.0.2)
+      json
     coffee-rails (4.2.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.2.x)
@@ -89,6 +92,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    json (2.0.2)
     kgio (2.10.0)
     launchy (2.4.3)
       addressable (~> 2.3)
@@ -226,6 +230,7 @@ DEPENDENCIES
   bootstrap-sass (~> 3.2.0)
   byebug
   capybara
+  capybara-webkit
   coffee-rails (~> 4.2)
   database_cleaner
   factory_girl_rails

--- a/spec/features/admin/a_admin_can_view_all_orders_spec.rb
+++ b/spec/features/admin/a_admin_can_view_all_orders_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 
 describe "An authorized admin visits /dashboard" do
+  self.use_transactional_tests = false
   scenario "an admin can view all orders" do
     trip1, trip2 = create_list(:trip, 22)
 
@@ -25,8 +26,7 @@ describe "An authorized admin visits /dashboard" do
   end
 
 
-  scenario "an admin can view orders by specific category" do
-    pending
+  scenario "an admin can view orders by specific category", js: true do
     trip1, trip2 = create_list(:trip, 2)
 
     admin_user = create(:user)
@@ -40,7 +40,7 @@ describe "An authorized admin visits /dashboard" do
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin_user)
     visit admin_dashboard_path
 
-    find(:css, '.dropdown').click_on("Paid")
+    select 'paid', from: 'status'
 
       expect(page).to have_content(trip2.title)
       expect(page).to_not have_content(trip1.title)

--- a/spec/features/carts/visitor_updates_the_quantity_of_an_item_in_their_cart_spec.rb
+++ b/spec/features/carts/visitor_updates_the_quantity_of_an_item_in_their_cart_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 feature "visitor changes the dropdown and clicks update" do
-  scenario "visitor sees their total price update" do
-    pending
+  self.use_transactional_tests = false
+  scenario "visitor sees their total price update", js: true do
     trip = create(:trip)
 
     visit '/trips'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ DatabaseCleaner[:active_record].strategy = :truncation
 RSpec.configure do |config|
   config.before(:all) do
     DatabaseCleaner.clean
+    Capybara.javascript_driver = :webkit
   end
 
   config.after(:each) do


### PR DESCRIPTION
I got the javascript tests to work. They are very slow and apparently thats a common thing.

There are basically 2 ways to test javascript with capybara and they both feel really messy... The first way is to use selenium. I chose not to do that because it would require each of us to install an outdated firefox driver somewhere in our path. Then it actually opens in the browser and takes f.o.r.e.v.e.r. Instead, I'm opted for capybara-webkit, which is headless (doesn't require a browser). Huge pain as well. 

Just for future reference for you guys, neither of these things know wtf to do with things you create in factory girl. The fix for this can been seen in both tests "self.use_transactional_tests = false". Of course, most online resources will point you to a deprecated version of this method.

I'm pretty sure everyone will need to do some setup to make these test work on local machines. Someone should try it without though, because I'm interested to see what happens. If it doesn't work like normal, run these lines from terminal:

```bash
brew install qt55
brew link --force qt55
```

webkit is dependent on this qt thinger https://github.com/thoughtbot/capybara-webkit/wiki/Installing-Qt-and-compiling-capybara-webkit